### PR TITLE
Add coin jar and global currency variable

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://scenes/level/level.tscn"
 config/features=PackedStringArray("4.3", "GL Compatibility")
 config/icon="res://icon.svg"
 
+[autoload]
+
+Globals="*res://scripts/globals.gd"
+
 [editor]
 
 version_control/plugin_name="GitPlugin"

--- a/scenes/item/coin_jar.gd
+++ b/scenes/item/coin_jar.gd
@@ -1,0 +1,16 @@
+extends Sprite2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	Globals.currency_updated.connect(update_coins)
+	update_coins()
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+
+func update_coins() -> void:
+	$Label.text = "$%.2f" % (float(Globals.currency) / 100.0)

--- a/scenes/level/level.tscn
+++ b/scenes/level/level.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://buxur252gmntr"]
+[gd_scene load_steps=4 format=3 uid="uid://buxur252gmntr"]
 
 [ext_resource type="Texture2D" uid="uid://uoxqnxqsxgrh" path="res://icon.svg" id="1_d1g14"]
 [ext_resource type="PackedScene" uid="uid://clpee6c07otbj" path="res://scenes/item/item.tscn" id="2_roxsd"]
+[ext_resource type="Script" path="res://scenes/item/coin_jar.gd" id="3_iah4v"]
 
 [node name="Level" type="Node2D"]
 
@@ -45,3 +46,15 @@ position = Vector2(893, 366)
 display_name = "Skibidi"
 texture = ExtResource("1_d1g14")
 costCents = 120
+
+[node name="Coin Jar" type="Sprite2D" parent="."]
+position = Vector2(76, 81)
+texture = ExtResource("1_d1g14")
+script = ExtResource("3_iah4v")
+
+[node name="Label" type="Label" parent="Coin Jar"]
+offset_left = -20.0
+offset_top = 41.0
+offset_right = 23.0
+offset_bottom = 64.0
+text = "Coins"

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -1,0 +1,8 @@
+extends Node
+
+signal currency_updated
+
+var currency: int = 0:
+	set(value):		
+		currency = max(0, value)
+		currency_updated.emit()


### PR DESCRIPTION
Adds an autoload script for storing the player's currency (accessible via `Globals.currency`) and a node that displays the current value on screen. 