### PR TITLE
Pipeline now runs when a PR is updated

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened]
 
 env:
   BUILD_PATH: /web/${{ github.ref }}


### PR DESCRIPTION
Previously, the pipeline was running when a PR was opened or reopened. But not when an open PR was modified. I've fixed this